### PR TITLE
weak protocol should be class type in swift 3

### DIFF
--- a/lib/boa/module/templates/swift/ModuleInterface.swift
+++ b/lib/boa/module/templates/swift/ModuleInterface.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-protocol <%= @prefixed_module %>ModuleInterface
+protocol <%= @prefixed_module %>ModuleInterface: class
 {
 
 }
 
-protocol <%= @prefixed_module %>ModuleDelegate
+protocol <%= @prefixed_module %>ModuleDelegate: class
 {
 
 }

--- a/lib/boa/module/templates/swift/Presenter.swift
+++ b/lib/boa/module/templates/swift/Presenter.swift
@@ -11,7 +11,7 @@ import Foundation
 class <%= @prefixed_module %>Presenter: NSObject, <%= @prefixed_module %>ModuleInterface
 {
     var interactor: <%= @prefixed_module %>Interactor?
-    weak var wireframe: <%= @prefixed_module %>Wireframe?
+    var wireframe: <%= @prefixed_module %>Wireframe?
     weak var userInterface: <%= @prefixed_module %>ViewInterface?
 
     // MARK: - <%= @prefixed_module %>ModuleInterface methods

--- a/lib/boa/module/templates/swift/ViewController.swift
+++ b/lib/boa/module/templates/swift/ViewController.swift
@@ -19,12 +19,12 @@ class <%= @prefixed_module %>ViewController: UIViewController, <%= @prefixed_mod
         super.viewDidLoad()
     }
 
-    override func viewWillAppear(animated: Bool)
+    override func viewWillAppear(_ animated: Bool)
     {
         super.viewWillAppear(animated)
     }
 
-    override func viewDidAppear(animated: Bool)
+    override func viewDidAppear(_ animated: Bool)
     {
         super.viewDidAppear(animated)
     }

--- a/lib/boa/module/templates/swift/ViewInterface.swift
+++ b/lib/boa/module/templates/swift/ViewInterface.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-protocol <%= @prefixed_module %>ViewInterface
+protocol <%= @prefixed_module %>ViewInterface: class
 {
 
 }

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -45,6 +45,7 @@ class <%= @prefixed_module %>Wireframe: NSObject
         view.eventHandler = presenter
 
         wireframe.presenter = presenter
+        wireframe.viewController = view
         wireframe.parameters = parameters
 
         interactor.presenter = presenter

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -29,10 +29,10 @@ class <%= @prefixed_module %>Wireframe: NSObject
     }
 
     class func presentFromViewController(_ viewController: UIViewController) {
-        let wireframe = <%= @prefixed_module &>Wireframe()
-        let presenter = <%= @prefixed_module &>Presenter()
-        let interactor = <%= @prefixed_module &>Interactor()
-        let dataManager = <%= @prefixed_module &>DataManager()
+        let wireframe = <%= @prefixed_module %>Wireframe()
+        let presenter = <%= @prefixed_module %>Presenter()
+        let interactor = <%= @prefixed_module %>Interactor()
+        let dataManager = <%= @prefixed_module %>DataManager()
 
         let view = <%= @prefixed_module &>ViewController(nibName: "<%= @prefixed_module %>ViewController", bundle: nil)
 

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -34,7 +34,7 @@ class <%= @prefixed_module %>Wireframe: NSObject
         let interactor = <%= @prefixed_module %>Interactor()
         let dataManager = <%= @prefixed_module %>DataManager()
 
-        let view = <%= @prefixed_module &>ViewController(nibName: "<%= @prefixed_module %>ViewController", bundle: nil)
+        let view = <%= @prefixed_module %>ViewController(nibName: "<%= @prefixed_module %>ViewController", bundle: nil)
 
         presenter.wireframe = wireframe
         presenter.interactor = interactor

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -15,6 +15,8 @@ class <%= @prefixed_module %>Wireframe: NSObject
     weak var presenter: <%= @prefixed_module %>Presenter?
     weak var viewController: <%= @prefixed_module %>ViewController?
 
+    var parameters: Any?
+
     func presentSelfFromViewController(viewController: UIViewController)
     {
         // save reference
@@ -28,7 +30,7 @@ class <%= @prefixed_module %>Wireframe: NSObject
         // *** present self with RootViewController
     }
 
-    class func presentFromViewController(_ viewController: UIViewController) {
+    class func presentFromViewController(_ viewController: UIViewController, _ parameters: Any? = nil) {
         let wireframe = <%= @prefixed_module %>Wireframe()
         let presenter = <%= @prefixed_module %>Presenter()
         let interactor = <%= @prefixed_module %>Interactor()
@@ -43,6 +45,7 @@ class <%= @prefixed_module %>Wireframe: NSObject
         view.eventHandler = presenter
 
         wireframe.presenter = presenter
+        wireframe.parameters = parameters
 
         interactor.presenter = presenter
         interactor.dataManager = dataManager

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -11,9 +11,9 @@ import UIKit
 
 class <%= @prefixed_module %>Wireframe: NSObject
 {
-    var rootWireframe: RootWireframe?
-    var presenter: <%= @prefixed_module %>Presenter?
-    var viewController: <%= @prefixed_module %>ViewController?
+    weak var rootWireframe: RootWireframe?
+    weak var presenter: <%= @prefixed_module %>Presenter?
+    weak var viewController: <%= @prefixed_module %>ViewController?
 
     func presentSelfFromViewController(viewController: UIViewController)
     {
@@ -26,5 +26,28 @@ class <%= @prefixed_module %>Wireframe: NSObject
 
         // present controller
         // *** present self with RootViewController
+    }
+
+    class func presentFromViewController(_ viewController: UIViewController) {
+        let wireframe = <%= @prefixed_module &>Wireframe()
+        let presenter = <%= @prefixed_module &>Presenter()
+        let interactor = <%= @prefixed_module &>Interactor()
+        let dataManager = <%= @prefixed_module &>DataManager()
+
+        let view = <%= @prefixed_module &>ViewController(nibName: "<%= @prefixed_module %>ViewController", bundle: nil)
+
+        presenter.wireframe = wireframe
+        presenter.interactor = interactor
+        presenter.userInterface = view
+
+        view.eventHandler = presenter
+
+        wireframe.presenter = presenter
+
+        interactor.presenter = presenter
+        interactor.dataManager = dataManager
+
+        //  Present View
+
     }
 }

--- a/lib/boa/module/templates/swift/Wireframe.swift
+++ b/lib/boa/module/templates/swift/Wireframe.swift
@@ -48,6 +48,10 @@ class <%= @prefixed_module %>Wireframe: NSObject
         interactor.dataManager = dataManager
 
         //  Present View
-
+        if let nav = viewController.navigationController {
+            nav.pushViewController(view, animated: true)
+        } else {
+            viewController.present(view, animated: true, completion: nil)
+        }
     }
 }

--- a/lib/boa/templates/swift/AppDependencies.swift
+++ b/lib/boa/templates/swift/AppDependencies.swift
@@ -12,7 +12,7 @@ import UIKit
 class <%= @project %>AppDependencies: NSObject
 {
 
-    class func initWithWindow(window: UIWindow) -> <%= @project %>AppDependencies
+    class func initWithWindow(_ window: UIWindow) -> <%= @project %>AppDependencies
     {
 
         let obj = <%= @project %>AppDependencies()
@@ -26,7 +26,7 @@ class <%= @project %>AppDependencies: NSObject
         // *** present first wireframe here
     }
 
-    func configureDependencies(window: UIWindow)
+    func configureDependencies(_ window: UIWindow)
     {
         // -----
         // root classes


### PR DESCRIPTION
In Swift 3, weak protocol should be class type, and we need to add '_' before first function parameter to skip first parameter prefix.